### PR TITLE
Add kid-friendly mode with font toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,13 @@
       body {
         font-family: 'Inter', sans-serif;
       }
+      body.kid-mode {
+        font-size: 18px;
+      }
+      body.kid-mode input,
+      body.kid-mode button {
+        font-size: 1.25rem;
+      }
     </style>
     <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="apple-touch-icon" href="/icons/icon-192.png" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,22 @@
+import { useEffect, useState } from 'react';
 import CardDamageCalculator from './CardDamageCalculator';
 
 export default function App() {
-  return <CardDamageCalculator />;
+  const [kidMode, setKidMode] = useState(false);
+
+  useEffect(() => {
+    document.body.classList.toggle('kid-mode', kidMode);
+  }, [kidMode]);
+
+  return (
+    <div>
+      <button
+        onClick={() => setKidMode(!kidMode)}
+        className="fixed top-4 right-4 bg-white/80 text-gray-800 px-4 py-2 rounded-lg shadow-lg hover:bg-white"
+      >
+        {kidMode ? 'Adult Mode' : 'Kid Mode'}
+      </button>
+      <CardDamageCalculator />
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add Kid Mode toggle in the app
- update index styling to enlarge text in kid mode

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a3b22eeb88320be5e28a7ddcfaa3a